### PR TITLE
doc: add installation and commands text on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Louper CLI
 
 ![](./.gifs/demo.gif)
+
+# Installation
+`npm install -g @mark3labs/louper-cli@latest`
+
+Or if you want specific version,
+`npm install -g @mark3labs/louper-cli@VERSION`
+
+# Commands
+`louper-cli --help`


### PR DESCRIPTION
This might be too obvious but I actually took some time to find out a way to install the louper-cli (the latest version is not available for some reason so I installed 0.5.4)

I also added `commands`, maybe later someone or I can update more detailed descriptions.